### PR TITLE
Update vendor files to HTMLunit 2.10

### DIFF
--- a/lib/akephalos/client/filter.rb
+++ b/lib/akephalos/client/filter.rb
@@ -14,7 +14,7 @@ module Akephalos
       # response.
       #
       # @param [WebRequest] request the pending HTTP request
-      # @return [WebResponseImpl] when the request matches a defined filter
+      # @return [WebResponse] when the request matches a defined filter
       # @return [nil] when no filters match the request
       def filter(request)
         if filter = find_filter(request)
@@ -28,7 +28,7 @@ module Akephalos
             HTTP_STATUS_CODES.fetch(filter[:status], "Unknown"),
             headers
           )
-          HtmlUnit::WebResponseImpl.new(response, request, Time.now - start_time)
+          HtmlUnit::WebResponse.new(response, request, Time.now - start_time)
         end
       end
 
@@ -49,7 +49,7 @@ module Akephalos
       #
       # @api htmlunit
       # @param [WebRequest] request the pending HTTP request
-      # @return [WebResponseImpl]
+      # @return [WebResponse]
       def getResponse(request)
         filter(request) || super
       end

--- a/lib/akephalos/htmlunit.rb
+++ b/lib/akephalos/htmlunit.rb
@@ -23,7 +23,7 @@ module HtmlUnit
   java_import "com.gargoylesoftware.htmlunit.SilentCssErrorHandler"
   java_import "com.gargoylesoftware.htmlunit.WebClient"
   java_import "com.gargoylesoftware.htmlunit.WebResponseData"
-  java_import "com.gargoylesoftware.htmlunit.WebResponseImpl"
+  java_import "com.gargoylesoftware.htmlunit.WebResponse"
 
   # Container module for com.gargoylesoftware.htmlunit.util namespace.
   module Util

--- a/lib/akephalos/page.rb
+++ b/lib/akephalos/page.rb
@@ -61,7 +61,7 @@ module Akephalos
 
     # @return [String] the current page's URL.
     def current_url
-      current_frame.getWebResponse.getRequestSettings.getUrl.toString
+      current_frame.getWebResponse.getWebRequest.getUrl.toString
     end
 
     # Execute JavaScript against the current page, discarding any return value.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
-require 'yaml'
+require "yaml"
+YAML::ENGINE.yamler= 'syck' if defined?(YAML::ENGINE)
 
 root = File.expand_path('../../', __FILE__)
 lib_paths = [root] + %w(vendor lib vendor).collect { |dir| File.join(root, dir) }
@@ -33,10 +34,7 @@ RSpec.configure do |config|
 
   config.filter_run_excluding(:platform => lambda { |value|
     return true if value == :jruby && !running_with_jruby
-  })                                   
-  
-  puts YAML::ENGINE.yamler
-  
+  })                                     
 end
 
 require File.join(spec_dir,"spec_helper")


### PR DESCRIPTION
HTMLUnit 2.10

Problems so far:

```
NameError: cannot load Java class com.gargoylesoftware.htmlunit.WebResponseImpl
```

Which is loaded at https://github.com/Nerian/akephalos2/blob/master/lib/akephalos/htmlunit.rb#L26

As the HTMLUnit docs state, that class should not be used in the first place, and I guess it is deprecated at 2.10 :)

http://htmlunit.sourceforge.net/apidocs/index.html
