### PR TITLE
Add support for accessing frames by index rather than just by ID

### DIFF
--- a/lib/akephalos/capybara.rb
+++ b/lib/akephalos/capybara.rb
@@ -235,11 +235,11 @@ class Capybara::Driver::Akephalos < Capybara::Driver::Base
 
   # Execute the given block within the context of a specified frame.
   #
-  # @param [String] frame_id the frame's id
+  # @param [String] frame_id the frame's id or index
   # @raise [Capybara::ElementNotFound] if the frame is not found
-  def within_frame(frame_id, &block)
-    unless page.within_frame(frame_id, &block)
-      raise Capybara::ElementNotFound, "Unable to find frame with id '#{frame_id}'"
+  def within_frame(frame_id_or_index, &block)
+    unless page.within_frame(frame_id_or_index, &block)
+      raise Capybara::ElementNotFound, "Unable to find frame with id '#{frame_id_or_index}'"
     end
   end
 

--- a/lib/akephalos/capybara.rb
+++ b/lib/akephalos/capybara.rb
@@ -238,6 +238,7 @@ class Capybara::Driver::Akephalos < Capybara::Driver::Base
   # @param [String] frame_id the frame's id or index
   # @raise [Capybara::ElementNotFound] if the frame is not found
   def within_frame(frame_id_or_index, &block)
+  	result = page.within_frame(frame_id_or_index, &block)
     unless page.within_frame(frame_id_or_index, &block)
       raise Capybara::ElementNotFound, "Unable to find frame with id '#{frame_id_or_index}'"
     end

--- a/lib/akephalos/page.rb
+++ b/lib/akephalos/page.rb
@@ -104,7 +104,7 @@ module Akephalos
     # @return [nil] if no frame is found
     def find_frame(id_or_index)
     	if id_or_index.is_a? Fixnum
-	    	frame = @_page.getFrames.get(id_or_index)
+	    	frame = @_page.getFrames.get(id_or_index) rescue nil
     	else	
     		frame = @_page.getFrames.find do |frame|
         		frame.getFrameElement.getAttribute("id") == id_or_index

--- a/lib/akephalos/page.rb
+++ b/lib/akephalos/page.rb
@@ -99,20 +99,20 @@ module Akephalos
       @current_frame || @_page
     end
 
-	# @param [String/Integer] id the frame's id or index
+    # @param [String/Integer] id the frame's id or index
     # @return [HtmlUnit::HtmlPage] the specified frame
     # @return [nil] if no frame is found
     def find_frame(id_or_index)
     	if id_or_index.is_a? Fixnum
-	    	frame = @_page.getFrames[id_or_index]
+	    	frame = @_page.getFrames.get(id_or_index)
     	else	
-	    	puts @_page.getFrames.inspect
     		frame = @_page.getFrames.find do |frame|
-        	frame.getFrameElement.getAttribute("id") == id_or_index
-        end
-      end
-      frame.getEnclosedPage if frame
+        		frame.getFrameElement.getAttribute("id") == id_or_index
+        	end
+      	end
+      	frame.getEnclosedPage if frame
     end
+    
   end
 
 end

--- a/lib/akephalos/page.rb
+++ b/lib/akephalos/page.rb
@@ -99,12 +99,17 @@ module Akephalos
       @current_frame || @_page
     end
 
-    # @param [String] id the frame's id
+	# @param [String/Integer] id the frame's id or index
     # @return [HtmlUnit::HtmlPage] the specified frame
     # @return [nil] if no frame is found
-    def find_frame(id)
-      frame = @_page.getFrames.find do |frame|
-        frame.getFrameElement.getAttribute("id") == id
+    def find_frame(id_or_index)
+    	if id_or_index.is_a? Fixnum
+	    	frame = @_page.getFrames[id_or_index]
+    	else	
+	    	puts @_page.getFrames.inspect
+    		frame = @_page.getFrames.find do |frame|
+        	frame.getFrameElement.getAttribute("id") == id_or_index
+        end
       end
       frame.getEnclosedPage if frame
     end

--- a/spec/integration/iframe_selection_spec.rb
+++ b/spec/integration/iframe_selection_spec.rb
@@ -10,16 +10,20 @@ describe Capybara::Session do
     context "iframe selection" do
       it "should select iframe by index" do
       	@session.visit('/iframe_selection_test')
+        @session.within_frame(0) do
+        	@session.should have_content("Frame 1")
+        end
         @session.within_frame(1) do
-        	@session.should have_content("derp")
+        	@session.should have_content("Frame 2")
         end
       end
       
 	  it "should select iframe by id" do
 	    @session.visit('/iframe_selection_test')
-        @session.within_frame('beefcake') do
-			@session.should have_content("tasty and delicious")
-			@session.should_not have_content("derp")
+        @session.within_frame('third') do
+			@session.should have_content("Frame 3")
+			@session.should_not have_content("Frame 2")
+			@session.should_not have_content("Frame 1")
         end
       end      
     end

--- a/spec/integration/iframe_selection_spec.rb
+++ b/spec/integration/iframe_selection_spec.rb
@@ -18,6 +18,11 @@ describe Capybara::Session do
         end
       end
       
+      it "should return the usual exception when selecting a crazy index" do
+      	@session.visit('/iframe_selection_test')
+        expect { @session.within_frame(9999) {} }.should raise_error(Capybara::ElementNotFound)
+      end
+      
 	  it "should select iframe by id" do
 	    @session.visit('/iframe_selection_test')
         @session.within_frame('third') do

--- a/spec/integration/iframe_selection_spec.rb
+++ b/spec/integration/iframe_selection_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Capybara::Session do
+  context 'with akephalos driver' do
+
+    before do
+      @session = Capybara::Session.new(:akephalos, Application)
+    end
+
+    context "iframe selection" do
+      it "should select iframe by index" do
+      	@session.visit('/iframe_selection_test')
+        @session.within_frame(1) do
+        	@session.should have_content("derp")
+        end
+      end
+      
+	  it "should select iframe by id" do
+	    @session.visit('/iframe_selection_test')
+        @session.within_frame('beefcake') do
+			@session.should have_content("tasty and delicious")
+			@session.should_not have_content("derp")
+        end
+      end      
+    end
+
+  end
+end
+

--- a/spec/support/application.rb
+++ b/spec/support/application.rb
@@ -102,6 +102,22 @@ class Application < TestApp
   </body>
     HTML
   end
+  
+  
+  get '/derp_text' do "<body>derp</body>" end
+  get '/tasty_text' do "<body>tasty and delicious</body>" end
+  
+  get '/iframe_selection_test' do
+   <<-HTML
+  <body>
+    <p id="test">Test</p>
+    <iframe id="beefcake" src="/tasty_text" />
+    <p id="test2">Test2</p>
+    <iframe class="stupidiframewithoutid" src="/derp_text" />
+  </body>
+    HTML
+  end
+  
 end
 
 if $0 == __FILE__

--- a/spec/support/application.rb
+++ b/spec/support/application.rb
@@ -104,16 +104,19 @@ class Application < TestApp
   end
   
   
-  get '/derp_text' do "<body>derp</body>" end
-  get '/tasty_text' do "<body>tasty and delicious</body>" end
+  get '/one_text' do "<body>Frame 1</body>" end
+  get '/two_text' do "<body>Frame 2</body>" end
+  get '/three_text' do "<body>Frame 3</body>" end
   
   get '/iframe_selection_test' do
    <<-HTML
   <body>
     <p id="test">Test</p>
-    <iframe id="beefcake" src="/tasty_text" />
+    <iframe id="first" src="/one_text"></iframe>
     <p id="test2">Test2</p>
-    <iframe class="stupidiframewithoutid" src="/derp_text" />
+  	<iframe class="second" src="/two_text"></iframe>
+  	<p id="test3">Test3</p>
+  	<iframe id="third" src="/three_text"></iframe>
   </body>
     HTML
   end


### PR DESCRIPTION
While the original capybara method (http://rubydoc.info/github/jnicklas/capybara/master/Capybara/Session#within_frame-instance_method) seems to want a string, capybara-webkit also accepts both (https://github.com/thoughtbot/capybara-webkit/blob/master/lib/capybara/driver/webkit.rb#L67-74).

It stays backwards compatible and is needed sometimes when an iframe doesn't actually have an ID

It is still missing tests, maybe we could steal the ones in capybara-webkit? (https://github.com/agibralter/capybara-webkit/commit/5a85fd992fae103d1e39432596e2c493c1254bbd)

Cheers,
Marc
