### PR TITLE
Encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ RSpec, Cucumber, and Test::Unit.
 Here's some sample RSpec code:
     
 ``` ruby
+# encoding: utf-8
+
 describe "Home Page" do
   before { visit "/" }
   
@@ -98,6 +100,8 @@ describe "Home Page" do
   
 end 
 ```
+
+Akephalos uses UTF-8 encoding. You may need to add `# encoding: utf-8` at the first line of your test.
 
 Capybara allows you to perform your action on a context, for example inside a div or a frame. With Akephalos you can select the frame either by id or by index.
 

--- a/bin/akephalos
+++ b/bin/akephalos
@@ -96,7 +96,7 @@ else
     # since the akephalos server doesn't have any gem dependencies and is
     # always executed with the same context, we clear RUBYOPT before running
     # exec.
-    ENV["RUBYOPT"] = "--1.9"
+    ENV["RUBYOPT"] = "--1.9" unless ENV['JRUBY_1_8']
     exec("java", *(java_args + ruby_args))  
   end
 end

--- a/spec/integration/domnode_spec.rb
+++ b/spec/integration/domnode_spec.rb
@@ -16,6 +16,8 @@ describe Capybara::Session do
       @session.find(:css, "p#line_feed").text.should           == "original html"
       @session.find(:css, "p#carriage_return").text.should     == "original html"
       @session.find(:css, "p#non_breaking_space").text.should  == " original  html "
+      @session.find(:css, "p#utf").text.should  == "uʍop ǝpısdn ɯ,ı 'ǝɯ ʇɐ ʞooן |"
+      
     end
 
     it "Element#native#text_content will return raw text including whitespace" do
@@ -26,6 +28,7 @@ describe Capybara::Session do
       @session.find(:css, "p#line_feed").native.text_content.should          == "\noriginal\n html\n"
       @session.find(:css, "p#carriage_return").native.text_content.should    == "\roriginal\r html\r"
       @session.find(:css, "p#non_breaking_space").native.text_content.should ==  "\302\240original\302\240 html\302\240"
+      @session.find(:css, "p#utf").native.text_content.should  == "   uʍop ǝpısdn ɯ,ı 'ǝɯ ʇɐ ʞooן |"
     end
 
     it "Element#native#xml will return the current DOM from the node as xml" do

--- a/spec/support/application.rb
+++ b/spec/support/application.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 class Application < TestApp
   get '/slow_page' do
     sleep 1
@@ -73,6 +74,7 @@ class Application < TestApp
     <p id="line_feed">&#10;original&#10; html&#10;</p>
     <p id="carriage_return">&#13;original&#13; html&#13;</p>
     <p id="non_breaking_space">&#160;original&#160; html&#160;</p>
+    <p id="utf">   uʍop ǝpısdn ɯ,ı 'ǝɯ ʇɐ ʞooן |</p>
   </body>
     HTML
   end


### PR DESCRIPTION
Provide a way to use JRuby in 1.8, while maintaining 1.9 as the default mode.
