### PR TITLE
Variable htmlunit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pkg
 tags
 .idea/
 *.gem
+.akephalos

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,4 @@ rvm:
   - 1.8.7
   - 1.9.3
   - jruby  
-before_script:
-  - git submodule update --init
-  - mkdir .akephalos
-  - mkdir .akephalos/2.9
-  - cp -r vendor/html-unit/ .akephalos/2.9/
 script: "bundle exec rspec spec -f p"  

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,10 @@ notifications:
 rvm:
   - 1.8.7
   - 1.9.3
-  - jruby  
-script: "bundle exec rspec spec -f p"  
+  - jruby
+before_script:
+  - git submodule update --init
+  - mkdir .akephalos
+  - mkdir .akephalos/2.9
+  - cp -r vendor/html-unit/ .akephalos/2.9/
+script: "bundle exec rspec spec -f p"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,7 @@ rvm:
   - jruby  
 before_script:
   - git submodule update --init
+  - mkdir .akephalos
+  - mkdir .akephalos/2.9
+  - cp -r vendor/html-unit/ .akephalos/2.9/
 script: "bundle exec rspec spec -f p"  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 notifications:
   email: false
 rvm:
-  - 1.8.7
   - 1.9.3
   - jruby
 before_script:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ gem 'akephalos2', :require => 'akephalos'
 Or (for the current master branch)
 
 ``` ruby
-gem 'akephalos2', :git => 'git://github.com/Nerian/akephalos2.git', :submodules => true
+gem 'akephalos2', :git => 'git://github.com/Nerian/akephalos2.git'
 ```
 
 Akephalos creates a `.akephalos` folder where it stores HTMLUnit binaries. You should set Git to ignore that folder.
@@ -55,10 +55,8 @@ We use GitHub issues:
 </a>
 
 ``` bash
-git clone --recursive https://github.com/Nerian/akephalos2
+git clone https://github.com/Nerian/akephalos2
 ```
-
-The HTMLUnit files are located at [https://github.com/Nerian/html-unit-vendor](https://github.com/Nerian/html-unit-vendor) and are automatically downloaded as a submodule.
 
 Also, we have a .rvmrc file already cooked:
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ ENV["htmlunit_version"] = "2.8"
 ENV["htmlunit_version"] = "2.7"
 ```
 
-It defaults to HtmlUnit 2.9
+It defaults to HtmlUnit 2.9. You can manually download or copy your own version to .akephalos/:version and use it with `ENV["htmlunit_version"] = "version"`
 
 ### Using a different browser
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ $ akephalos -m 670
 The Htmlunit version is configured with a environmental variable named `htmlunit_version`. The possible versions are listed at [here](http://sourceforge.net/projects/htmlunit/files/htmlunit/)
 
 ```
+ENV["htmlunit_version"] = "2.10"  # Development Snapshots
 ENV["htmlunit_version"] = "2.9"
 ENV["htmlunit_version"] = "2.8"
 ENV["htmlunit_version"] = "2.7"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Important Notice
 
-This repo has rewritten its history and as such is not compatible with the main Akephalos repo. 
- 
+This repo has rewritten its history and as such is not compatible with the main Akephalos repo.
+
 You can get the unaltered – before history rewrite – pristine copy at: [https://github.com/Nerian/akephalos](https://github.com/Nerian/akephalos)
 
 Further development will be done here:
@@ -10,7 +10,7 @@ Further development will be done here:
 The reason why its history was rewrote was to remove .jar vendor files that were making its size huge.
 
 
-# Akephalos        
+# Akephalos
 
 Akephalos is a full-stack headless browser for integration testing with
 [Capybara](https://github.com/jnicklas/capybara). It is built on top of [HtmlUnit](http://htmlunit.sourceforge.net),
@@ -19,10 +19,10 @@ MRI with no need for JRuby to be installed on the system.
 
 
 ## Installation
-     
+
 ``` ruby
 gem install akephalos2
-```     
+```
 
 Or
 
@@ -30,10 +30,16 @@ Or
 gem 'akephalos2', :require => 'akephalos'
 ```
 
-Or (for the current master branch)  
+Or (for the current master branch)
 
 ``` ruby
 gem 'akephalos2', :git => 'git://github.com/Nerian/akephalos2.git', :submodules => true
+```
+
+Akephalos creates a `.akephalos` folder where it stores HTMLUnit binaries. You should set Git to ignore that folder.
+
+```
+git ignore .akephalos
 ```
 
 # Questions, bugs, etc:
@@ -49,7 +55,7 @@ We use GitHub issues:
 </a>
 
 ``` bash
-git clone --recursive https://github.com/Nerian/akephalos2 
+git clone --recursive https://github.com/Nerian/akephalos2
 ```
 
 The HTMLUnit files are located at [https://github.com/Nerian/html-unit-vendor](https://github.com/Nerian/html-unit-vendor) and are automatically downloaded as a submodule.
@@ -59,7 +65,7 @@ Also, we have a .rvmrc file already cooked:
 ``` bash
 cp .rvmrc.example .rvmrc
 ```
-  
+
 ## Setup
 
 Configuring akephalos is as simple as requiring it and setting Capybara's
@@ -79,26 +85,26 @@ makes no assumptions about the testing framework being used, and works with
 RSpec, Cucumber, and Test::Unit.
 
 Here's some sample RSpec code:
-    
+
 ``` ruby
 # encoding: utf-8
 
 describe "Home Page" do
   before { visit "/" }
-  
+
   context "searching" do
-  
+
     before do
-      fill_in "Search", :with => "akephalos" 
+      fill_in "Search", :with => "akephalos"
       click_button "Go"
     end
-    
+
     it "returns results" { page.should have_css("#results") }
-    
+
     it "includes the search term" { page.should have_content("akephalos") }
   end
-  
-end 
+
+end
 ```
 
 ### Encoding
@@ -138,25 +144,35 @@ end
 ## Configuration
 
 There are now a few configuration options available through Capybara's new
-`register_driver` API.    
+`register_driver` API.
 
-### Configuring the max memory that Java Virtual Machine can use
+### Configure the max memory that Java Virtual Machine can use
 
 The max memory that the JVM is going to use can be set using an environment variable in your spec_helper or .bashrc file.
 
-``` ruby                                                                            
+``` ruby
 ENV['akephalos_jvm_max_memory']
-```                              
-  
+```
 
 The default value is 128 MB.
 
-If you use akephalos's bin the parameter `-m [memory]` sets the max memory for the JVM.
+If you use Akephalos's bin the parameter `-m [memory]` sets the max memory for the JVM.
 
 ``` bash
 $ akephalos -m 670
-``` 
+```
 
+### Configure the version of HTMLUnit
+
+The Htmlunit version is configured with a environmental variable named `htmlunit_version`. The possible versions are listed at [here](http://sourceforge.net/projects/htmlunit/files/htmlunit/)
+
+```
+ENV["htmlunit_version"] = "2.9"
+ENV["htmlunit_version"] = "2.8"
+ENV["htmlunit_version"] = "2.7"
+```
+
+It defaults to HtmlUnit 2.9
 
 ### Using a different browser
 
@@ -169,16 +185,16 @@ Capybara.register_driver :akephalos do |app|
   #  available options:
   #  :ie6, :ie7, :ie8, :firefox_3_6
   Capybara::Driver::Akephalos.new(app, :browser => :ie8)
-end     
-```   
+end
+```
 
 
 ### Using a Proxy Server
-       
-``` ruby         
+
+``` ruby
 Capybara.register_driver :akephalos do |app|
   Capybara::Driver::Akephalos.new(app, :http_proxy => 'myproxy.com', :http_proxy_port => 8080)
-end 
+end
 ```
 
 
@@ -190,40 +206,40 @@ that certain libraries aren't supported by HtmlUnit. If possible, it's
 best to keep the default behaviour, and use Filters (see below) to mock
 offending libraries. If needed, however, you can configure Akephalos to
 ignore javascript errors.
-           
+
 ``` ruby
 Capybara.register_driver :akephalos do |app|
   Capybara::Driver::Akephalos.new(app, :validate_scripts => false)
-end 
-```  
-       
+end
+```
+
 
 ### Setting the HtmlUnit log level
 
 By default it uses the 'fatal' level. You can change that like this:
-        
+
 ``` ruby
-Capybara.register_driver :akephalos do |app|  
-  # available options 
+Capybara.register_driver :akephalos do |app|
+  # available options
   # "trace", "debug", "info", "warn", "error", or "fatal"
   Capybara::Driver::Akephalos.new(app, :htmlunit_log_level => 'fatal')
-end 
+end
 ```
-       
+
 
 ### Running Akephalos with Spork
-         
+
 ``` ruby
 Spork.prefork do
   ...
-  Akephalos::RemoteClient.manager                                 
+  Akephalos::RemoteClient.manager
 end
 
-Spork.each_run do 
+Spork.each_run do
   ...
   Thread.current['DRb'] = { 'server' => DRb::DRbServer.new }
 end
-```       
+```
 
 
 More info at : [sporking-with-akephalos](http://spacevatican.org/2011/7/3/sporking-with-akephalos)
@@ -232,28 +248,28 @@ More info at : [sporking-with-akephalos](http://spacevatican.org/2011/7/3/sporki
 
 Akephalos allows you to filter requests originating from the browser and return mock responses. This will let you easily filter requests for external resources when running your tests, such as Facebook's API and Google Analytics.
 
-Configuring filters in Akephalos should be familiar to anyone who has used FakeWeb or a similar library. The simplest filter requires only an HTTP method (:get, :post, :put, :delete, :any) and a string or regex to match against.       
-         
+Configuring filters in Akephalos should be familiar to anyone who has used FakeWeb or a similar library. The simplest filter requires only an HTTP method (:get, :post, :put, :delete, :any) and a string or regex to match against.
+
 ``` ruby
 Akephalos.filter(:get, "http://www.google.com")
 Akephalos.filter(:any, %r{^http://(api\.)?twitter\.com/.*$})
 ```
-	      
-	
+
+
 By default, all filtered requests will return an empty body with a 200 status code. You can change this by passing additional options to your filter call.
-   
+
 ``` ruby
-Akephalos.filter(:get, "http://google.com/missing", 
+Akephalos.filter(:get, "http://google.com/missing",
   :status => 404, :body => "... <h1>Not Found</h1> ...")
 
 Akephalos.filter(:post, "http://my-api.com/resource.xml",
   :status => 201, :headers => {
     "Content-Type" => "application/xml",
     "Location" => "http://my-api.com/resources/1.xml" },
-    :body => {:id => 100}.to_xml)	
-```    
+    :body => {:id => 100}.to_xml)
+```
 
-                                         
+
 And that's really all there is to it! It should be fairly trivial to set up filters for the external resources you need to fake. For reference, however, here's what we ended up using for our external sources.
 
 #### Example: Google Maps
@@ -262,8 +278,8 @@ Google Analytics code is passively applied based on HTML comments, so simply ret
 
 ``` ruby
 Akephalos.filter(:get, "http://www.google-analytics.com/ga.js",
-  :headers => {"Content-Type" => "application/javascript"})    
-```       
+  :headers => {"Content-Type" => "application/javascript"})
+```
 
 
 Google Maps requires the most extensive amount of API definitions of the three, but these few lines cover everything we've encountered so far.
@@ -278,24 +294,24 @@ Akephalos.filter(:get, "http://maps.google.com/maps/api/js?sensor=false",
       Marker: function(){},
       MapTypeId: {ROADMAP:1}
     }
-   };") 
-```  
+   };")
+```
 
-		
+
 #### Example: Facebook Connect
 
 Facebook Connect
 
-When you enable Facebook Connect on your page, the FeatureLoader is requested, and then additional resources are loaded when you call FB_RequireFeatures. We can therefore return an empty function from our filter to disable all Facebook Connect code.		                 
+When you enable Facebook Connect on your page, the FeatureLoader is requested, and then additional resources are loaded when you call FB_RequireFeatures. We can therefore return an empty function from our filter to disable all Facebook Connect code.
 
 ``` ruby
-Akephalos.filter(:get, 
+Akephalos.filter(:get,
   "http://static.ak.connect.facebook.com/js/api_lib/v0.4/FeatureLoader.js.php",
   :headers => {"Content-Type" => "application/javascript"},
-  :body => "window.FB_RequireFeatures = function() {};")    
-```        
+  :body => "window.FB_RequireFeatures = function() {};")
+```
 
-		
+
 ### Akephalos' Interactive mode
 
 #### bin/akephalos
@@ -305,23 +321,23 @@ The bundled akephalos binary provides a command line interface to a few useful f
 #### akephalos --interactive
 
 Running Akephalos in interactive mode gives you an IRB context for interacting with your site just as you would in your tests:
-         
+
 ``` ruby
 $ akephalos --interactive
   ->  Capybara.app_host # => "http://localhost:3000"
   ->  page.visit "/"
   ->  page.fill_in "Search", :with => "akephalos"
   ->  page.click_button "Go"
-  ->  page.has_css?("#search_results") # => true  
+  ->  page.has_css?("#search_results") # => true
 ```
-	     
-	
+
+
 #### akephalos --use-htmlunit-snapshot
-	
+
 This will instruct Akephalos to use the latest development snapshot of HtmlUnit as found on it's Cruise Control server. HtmlUnit and its dependencies will be unpacked into vendor/htmlunit in the current working directory.
 
 This is what the output looks like:
-      
+
 ``` ruby
 $ akephalos --use-htmlunit-snapshot
 
@@ -329,9 +345,9 @@ Downloading latest snapshot... done
 Extracting dependencies... done
 ========================================
 The latest HtmlUnit snapshot has been extracted to vendor/htmlunit!
-Once HtmlUnit has been extracted, Akephalos will automatically detect 
+Once HtmlUnit has been extracted, Akephalos will automatically detect
 the vendored version and use it instead of the bundled version.
-```          
+```
 
 
 #### akephalos --server <socket_file>

--- a/bin/akephalos
+++ b/bin/akephalos
@@ -4,8 +4,9 @@
 require "pathname"
 require "optparse"
 require 'rubygems'
+require "akephalos/htmlunit_downloader"
 
-options = { :interactive => false, :default_jvm_max_memory => '128' }
+options = { :interactive => false, :default_jvm_max_memory => '128'}
 
 parser = OptionParser.new do |opts|
   opts.banner = "Usage: akephalos [--interactive, --use-htmlunit-snapshot, --memory [number]] | [--server] <port>"
@@ -13,19 +14,20 @@ parser = OptionParser.new do |opts|
   opts.on("-i", "--interactive", "Run in interactive mode") { options[:interactive] = true }
   opts.on("--use-htmlunit-snapshot", "Use the snapshot of htmlunit") { options[:use_htmlunit_snapshot] = true }
   opts.on("-m", "--memory [number]", "Max memory for the Java Virtual Machine, defaults to #{options[:default_jvm_max_memory]}
-  or env variable $akephalos_jvm_max_memory") do |memory| 
+  or env variable $akephalos_jvm_max_memory") do |memory|
     options[:akephalos_jvm_max_memory] = memory.to_s
-  end       
-  
+  end
+
   if options[:akephalos_jvm_max_memory].nil?
-    if ENV['akephalos_jvm_max_memory'].nil?     
+    if ENV['akephalos_jvm_max_memory'].nil?
       options[:akephalos_jvm_max_memory] = options[:default_jvm_max_memory]
     else
       options[:akephalos_jvm_max_memory] = ENV['akephalos_jvm_max_memory']
     end
-  end  
-  
-  puts "Using #{options[:akephalos_jvm_max_memory]} MB for the JVM"                           
+  end
+  puts "Using #{options[:akephalos_jvm_max_memory]} MB for the JVM"
+
+  HtmlUnit.download_htmlunit(ENV["htmlunit_version"])
 
   opts.on_tail("-h", "--help", "Show this message") { puts opts; exit }
 end
@@ -74,10 +76,10 @@ else
     require 'akephalos/server'
     Akephalos::Server.start!(port)
   else
-    require 'jruby-jars'              
+    require 'jruby-jars'
 
     jruby = JRubyJars.core_jar_path
-    jruby_stdlib = JRubyJars.stdlib_jar_path          
+    jruby_stdlib = JRubyJars.stdlib_jar_path
 
     java_args = [
      "-Xmx#{options[:akephalos_jvm_max_memory]}M",
@@ -85,7 +87,7 @@ else
       "org.jruby.Main",
       "-X+O"
     ]
-    ruby_args = [ 
+    ruby_args = [
       "-Ku",
       "-I", ["vendor", lib, src].join(File::PATH_SEPARATOR),
       "-r", "akephalos/server",
@@ -101,6 +103,6 @@ else
     else
       ENV["RUBYOPT"] = "--1.9"
     end
-    exec("java", *(java_args + ruby_args))  
+    exec("java", *(java_args + ruby_args))
   end
 end

--- a/lib/akephalos.rb
+++ b/lib/akephalos.rb
@@ -8,6 +8,7 @@ require 'pathname'
 
 module Akephalos
   BIN_DIR = Pathname(__FILE__).expand_path.dirname.parent + 'bin'
+  ENV['htmlunit_version'] ||= "2.9" 
 end
 
 require 'akephalos/client'

--- a/lib/akephalos/client.rb
+++ b/lib/akephalos/client.rb
@@ -3,7 +3,7 @@ require 'akephalos/configuration'
 if RUBY_PLATFORM != "java"
   require 'akephalos/remote_client'
   Akephalos::Client = Akephalos::RemoteClient
-else
+else  
   require 'akephalos/htmlunit'
   require 'akephalos/htmlunit/ext/http_method'
   require 'akephalos/htmlunit/ext/confirm_handler'
@@ -12,7 +12,7 @@ else
   require 'akephalos/node'
 
   require 'akephalos/client/cookies'
-  require 'akephalos/client/filter'
+  require 'akephalos/client/filter'  
 
   module Akephalos
 
@@ -150,7 +150,7 @@ else
       # validate scripts, and htmlunit log level.
       #
       # @param [Hash] options the options to process
-      def process_options!(options)
+      def process_options!(options)        
         options = DEFAULT_OPTIONS.merge(options)
 
         @browser_version  = BROWSER_VERSIONS.fetch(options.delete(:browser))
@@ -158,7 +158,7 @@ else
         @use_insecure_ssl = options.delete(:use_insecure_ssl)
         @htmlunit_log_level = options.delete(:htmlunit_log_level)
         @http_proxy = options.delete(:http_proxy)
-        @http_proxy_port = options.delete(:http_proxy_port)
+        @http_proxy_port = options.delete(:http_proxy_port)        
 
         java.lang.System.setProperty("org.apache.commons.logging.simplelog.defaultlog", @htmlunit_log_level)
       end

--- a/lib/akephalos/htmlunit.rb
+++ b/lib/akephalos/htmlunit.rb
@@ -1,7 +1,7 @@
 require "pathname"
 require "java"
 
-Dir[File.dirname(__FILE__) + "/../.." + "/vendor/html-unit/*.jar"].each {|file| require file }
+Dir[File.dirname(__FILE__) + "/../.." + "/.akephalos/#{ENV['htmlunit_version']}/*.jar"].each {|file| require file }
 
 java.lang.System.setProperty("org.apache.commons.logging.Log", "org.apache.commons.logging.impl.SimpleLog")
 java.lang.System.setProperty("org.apache.commons.logging.simplelog.defaultlog", "fatal")

--- a/lib/akephalos/htmlunit_downloader.rb
+++ b/lib/akephalos/htmlunit_downloader.rb
@@ -18,11 +18,14 @@ module HtmlUnit
 
   def self.unzip(version)
     `tar xzf htmlunit-#{version}.zip`
+    `mv -f htmlunit-2.10-SNAPSHOT htmlunit-2.10 > /dev/null 2>&1`
     `cp -r htmlunit-#{version}/lib/ .akephalos/#{version}/`
   end
 
   def self.download(version)
-    if version[2] < '9'
+    if version == "2.10"
+      %x[curl -L -o htmlunit-2.10.zip  http://build.canoo.com/htmlunit/artifacts/htmlunit-2.10-SNAPSHOT-with-dependencies.zip]
+    elsif version[2] < '9'
       %x[curl -L -O http://sourceforge.net/projects/htmlunit/files/htmlunit/#{version}/htmlunit-#{version}.zip]
     else
       %x[curl -L -o htmlunit-#{version}.zip  http://sourceforge.net/projects/htmlunit/files/htmlunit/#{version}/htmlunit-#{version}-bin.zip]

--- a/lib/akephalos/htmlunit_downloader.rb
+++ b/lib/akephalos/htmlunit_downloader.rb
@@ -11,33 +11,25 @@ module HtmlUnit
       puts "Using HTMLUnit #{version}"
     end
   end
-  
+
   def self.version_exist?(version)
-    File.exist?(".akephalos/#{version}/htmlunit-#{version}.jar")    
+    File.exist?(".akephalos/#{version}/htmlunit-#{version}.jar")
   end
-  
+
   def self.unzip(version)
-    if version[2] < '9'
-      %x[unzip -j -d .akephalos/#{version} htmlunit-#{version}.zip htmlunit-#{version}/lib htmlunit-#{version}/lib/*]
-    else
-      %x[unzip -j -d .akephalos/#{version} htmlunit-#{version}-bin.zip htmlunit-#{version}/lib htmlunit-#{version}/lib/*]
-    end
-    
+    `tar xf htmlunit-#{version}.zip`
+    `cp -r htmlunit-#{version}/lib/ .akephalos/#{version}/`
   end
-  
+
   def self.download(version)
     if version[2] < '9'
       %x[curl -L -O http://sourceforge.net/projects/htmlunit/files/htmlunit/#{version}/htmlunit-#{version}.zip]
     else
-      %x[curl -L -O http://sourceforge.net/projects/htmlunit/files/htmlunit/#{version}/htmlunit-#{version}-bin.zip]
+      %x[curl -L -o htmlunit-#{version}.zip  http://sourceforge.net/projects/htmlunit/files/htmlunit/#{version}/htmlunit-#{version}-bin.zip]
     end
   end
-  
+
   def self.remove_cache(version)
-    if version[2] < '9'    
-      File.unlink "htmlunit-#{version}.zip"
-    else
-      File.unlink "htmlunit-#{version}-bin.zip"
-    end
-  end  
+    `rm -rf htmlunit-#{version} htmlunit-#{version}.zip`
+  end
 end

--- a/lib/akephalos/htmlunit_downloader.rb
+++ b/lib/akephalos/htmlunit_downloader.rb
@@ -17,7 +17,7 @@ module HtmlUnit
   end
 
   def self.unzip(version)
-    `tar xf htmlunit-#{version}.zip`
+    `tar xzf htmlunit-#{version}.zip`
     `cp -r htmlunit-#{version}/lib/ .akephalos/#{version}/`
   end
 

--- a/lib/akephalos/htmlunit_downloader.rb
+++ b/lib/akephalos/htmlunit_downloader.rb
@@ -1,0 +1,43 @@
+module HtmlUnit
+  def self.download_htmlunit(version)
+    if not version_exist?(version)
+      puts "Installing HTMLUnit #{version} at .akephalos/#{version}/"
+      Dir.mkdir(".akephalos") unless File.exists?(".akephalos")
+      Dir.mkdir(".akephalos/#{version}") unless File.exists?(".akephalos/#{version}")
+      download(version)
+      unzip(version)
+      remove_cache(version)
+    else
+      puts "Using HTMLUnit #{version}"
+    end
+  end
+  
+  def self.version_exist?(version)
+    File.exist?(".akephalos/#{version}/htmlunit-#{version}.jar")    
+  end
+  
+  def self.unzip(version)
+    if version[2] < '9'
+      %x[unzip -j -d .akephalos/#{version} htmlunit-#{version}.zip htmlunit-#{version}/lib htmlunit-#{version}/lib/*]
+    else
+      %x[unzip -j -d .akephalos/#{version} htmlunit-#{version}-bin.zip htmlunit-#{version}/lib htmlunit-#{version}/lib/*]
+    end
+    
+  end
+  
+  def self.download(version)
+    if version[2] < '9'
+      %x[curl -L -O http://sourceforge.net/projects/htmlunit/files/htmlunit/#{version}/htmlunit-#{version}.zip]
+    else
+      %x[curl -L -O http://sourceforge.net/projects/htmlunit/files/htmlunit/#{version}/htmlunit-#{version}-bin.zip]
+    end
+  end
+  
+  def self.remove_cache(version)
+    if version[2] < '9'    
+      File.unlink "htmlunit-#{version}.zip"
+    else
+      File.unlink "htmlunit-#{version}-bin.zip"
+    end
+  end  
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,10 @@ RSpec.configure do |config|
   config.before(:each, :full_description => /drag and drop/) do
     pending "drag and drop is not supported yet"
   end
+  
+  config.before(:suite) do
+    `rm -rf .akephalos`
+  end
 
   config.filter_run_excluding(:platform => lambda { |value|
     return true if value == :jruby && !running_with_jruby

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,8 @@ end
                              
 RSpec.configure do |config|
   running_with_jruby = RUBY_PLATFORM =~ /java/
+  
+  config.treat_symbols_as_metadata_keys_with_true_values = true
 
   warn "[AKEPHALOS] ** Skipping JRuby-only specs" unless running_with_jruby
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,8 +31,10 @@ RSpec.configure do |config|
     pending "drag and drop is not supported yet"
   end
   
-  config.before(:suite) do
-    `rm -rf .akephalos`
+  unless ENV['TRAVIS']
+    config.before(:suite) do
+      `rm -rf .akephalos`
+    end
   end
 
   config.filter_run_excluding(:platform => lambda { |value|

--- a/spec/unit/htmlunit_downloader_spec.rb
+++ b/spec/unit/htmlunit_downloader_spec.rb
@@ -47,4 +47,10 @@ describe "Integration test" do
     HtmlUnit.download_htmlunit("2.9")
     File.exist?(".akephalos/2.9/htmlunit-2.9.jar").should == true
   end
+  
+  it "should set up htmlunit 2.10" do
+    `rm -rf .akephalos`
+    HtmlUnit.download_htmlunit("2.10")
+    File.exist?(".akephalos/2.10/htmlunit-2.10-SNAPSHOT.jar").should == true
+  end
 end

--- a/spec/unit/htmlunit_downloader_spec.rb
+++ b/spec/unit/htmlunit_downloader_spec.rb
@@ -45,6 +45,6 @@ describe "Integration test" do
   it "should set up htmlunit 2.9" do
     `rm -rf .akephalos`
     HtmlUnit.download_htmlunit("2.9")
-    File.exist?(".akephalos/2.9/htmlunit-2.9.jar")
+    File.exist?(".akephalos/2.9/htmlunit-2.9.jar").should == true
   end
 end

--- a/spec/unit/htmlunit_downloader_spec.rb
+++ b/spec/unit/htmlunit_downloader_spec.rb
@@ -1,0 +1,50 @@
+require_relative "../../lib/akephalos/htmlunit_downloader"
+
+describe "Download HTMLUnit" do
+  
+  before(:each) do
+    `rm -rf .akephalos`
+    HtmlUnit.stub(:download).with("2.9").and_return(true)
+    HtmlUnit.stub(:remove_cache).with("2.9").and_return(true)
+    HtmlUnit.stub(:unzip).with("2.9").and_return(true)
+  end
+  
+  it "should creates .akephalos folder" do
+    HtmlUnit.download_htmlunit("2.9")
+    File.exists?(".akephalos").should == true
+  end
+  
+  it "should creates folder for that version" do
+    HtmlUnit.download_htmlunit("2.9")
+    File.exists?(".akephalos/2.9").should == true
+  end
+  
+  it "should download that version" do
+    HtmlUnit.should_receive(:download).with("2.9").and_return(true)
+    HtmlUnit.download_htmlunit("2.9")
+  end
+  
+  it "should unzip it" do
+    HtmlUnit.should_receive(:unzip).with("2.9").and_return(true)
+    HtmlUnit.download_htmlunit("2.9")
+  end
+  
+  it "should remove the cache file" do
+    HtmlUnit.should_receive(:remove_cache).with("2.9").and_return(true)
+    HtmlUnit.download_htmlunit("2.9")
+  end
+  
+  it "should just use it if already present" do
+    HtmlUnit.stub(:version_exist?).and_return(true)
+    HtmlUnit.should_not_receive(:remove_cache)
+    HtmlUnit.download_htmlunit("2.9")
+  end
+end
+
+describe "Integration test" do
+  it "should set up htmlunit 2.9" do
+    `rm -rf .akephalos`
+    HtmlUnit.download_htmlunit("2.9")
+    File.exist?(".akephalos/2.9/htmlunit-2.9.jar")
+  end
+end

--- a/spec/unit/htmlunit_downloader_spec.rb
+++ b/spec/unit/htmlunit_downloader_spec.rb
@@ -1,56 +1,58 @@
 require_relative "../../lib/akephalos/htmlunit_downloader"
 
-describe "Download HTMLUnit" do
+unless ENV['TRAVIS']
+  describe "Download HTMLUnit" do
   
-  before(:each) do
-    `rm -rf .akephalos`
-    HtmlUnit.stub(:download).with("2.9").and_return(true)
-    HtmlUnit.stub(:remove_cache).with("2.9").and_return(true)
-    HtmlUnit.stub(:unzip).with("2.9").and_return(true)
-  end
+    before(:each) do
+      `rm -rf .akephalos`
+      HtmlUnit.stub(:download).with("2.9").and_return(true)
+      HtmlUnit.stub(:remove_cache).with("2.9").and_return(true)
+      HtmlUnit.stub(:unzip).with("2.9").and_return(true)
+    end
   
-  it "should creates .akephalos folder" do
-    HtmlUnit.download_htmlunit("2.9")
-    File.exists?(".akephalos").should == true
-  end
+    it "should creates .akephalos folder" do
+      HtmlUnit.download_htmlunit("2.9")
+      File.exists?(".akephalos").should == true
+    end
   
-  it "should creates folder for that version" do
-    HtmlUnit.download_htmlunit("2.9")
-    File.exists?(".akephalos/2.9").should == true
-  end
+    it "should creates folder for that version" do
+      HtmlUnit.download_htmlunit("2.9")
+      File.exists?(".akephalos/2.9").should == true
+    end
   
-  it "should download that version" do
-    HtmlUnit.should_receive(:download).with("2.9").and_return(true)
-    HtmlUnit.download_htmlunit("2.9")
-  end
+    it "should download that version" do
+      HtmlUnit.should_receive(:download).with("2.9").and_return(true)
+      HtmlUnit.download_htmlunit("2.9")
+    end
   
-  it "should unzip it" do
-    HtmlUnit.should_receive(:unzip).with("2.9").and_return(true)
-    HtmlUnit.download_htmlunit("2.9")
-  end
+    it "should unzip it" do
+      HtmlUnit.should_receive(:unzip).with("2.9").and_return(true)
+      HtmlUnit.download_htmlunit("2.9")
+    end
   
-  it "should remove the cache file" do
-    HtmlUnit.should_receive(:remove_cache).with("2.9").and_return(true)
-    HtmlUnit.download_htmlunit("2.9")
-  end
+    it "should remove the cache file" do
+      HtmlUnit.should_receive(:remove_cache).with("2.9").and_return(true)
+      HtmlUnit.download_htmlunit("2.9")
+    end
   
-  it "should just use it if already present" do
-    HtmlUnit.stub(:version_exist?).and_return(true)
-    HtmlUnit.should_not_receive(:remove_cache)
-    HtmlUnit.download_htmlunit("2.9")
+    it "should just use it if already present" do
+      HtmlUnit.stub(:version_exist?).and_return(true)
+      HtmlUnit.should_not_receive(:remove_cache)
+      HtmlUnit.download_htmlunit("2.9")
+    end
   end
-end
 
-describe "Integration test" do
-  it "should set up htmlunit 2.9" do
-    `rm -rf .akephalos`
-    HtmlUnit.download_htmlunit("2.9")
-    File.exist?(".akephalos/2.9/htmlunit-2.9.jar").should == true
-  end
+  describe "Integration test" do
+    it "should set up htmlunit 2.9" do
+      `rm -rf .akephalos`
+      HtmlUnit.download_htmlunit("2.9")
+      File.exist?(".akephalos/2.9/htmlunit-2.9.jar").should == true
+    end
   
-  it "should set up htmlunit 2.10" do
-    `rm -rf .akephalos`
-    HtmlUnit.download_htmlunit("2.10")
-    File.exist?(".akephalos/2.10/htmlunit-2.10-SNAPSHOT.jar").should == true
+    it "should set up htmlunit 2.10" do
+      `rm -rf .akephalos`
+      HtmlUnit.download_htmlunit("2.10")
+      File.exist?(".akephalos/2.10/htmlunit-2.10-SNAPSHOT.jar").should == true
+    end
   end
 end


### PR DESCRIPTION
Right now the HTMLUnit version that Akephalos uses is pretty much hardcoded. It is a very hard dependency since it has to download an entire git repo. 

Granted, I could be rewriting the history of that repo all the time in order to eliminate duplicated binaries and such, but this approach sucks. 

We need to handle this dependency in a dynamic way that allows the developer to choose what HTMLUnit version is used, in a per project basis.

Interface:

``` ruby
#spec_helper

ENV["htmlunit_version"] = "2.8"
```

Akephalos will default to 2.9. So the first time that Akephalos is used, it is going to check if the code for HTMLUnit 2.9 has been downloaded. If it is not downloaded, then it downloads it. 

The download will be stored at  `.akephalos/:version/`   in the Rails (or whatever you are testing) project folder.

So you could potentially use your own version code of HTMLUnit; just store it there and use the adequate `htmlunit_version` string 

This folder should be ignored by git.

The HTMLUnit downloads are located at:

http://sourceforge.net/projects/htmlunit/files/htmlunit/

This potentially solves #20 use case.
