### PR TITLE
Improved NativeException handling

### DIFF
--- a/lib/akephalos/client.rb
+++ b/lib/akephalos/client.rb
@@ -8,6 +8,7 @@ else
   require 'akephalos/htmlunit/ext/http_method'
   require 'akephalos/htmlunit/ext/confirm_handler'
 
+  require 'akephalos/exception_handling_delegators'
   require 'akephalos/page'
   require 'akephalos/node'
 

--- a/lib/akephalos/client.rb
+++ b/lib/akephalos/client.rb
@@ -22,6 +22,16 @@ else
     # allowing navigation.
     class Client
 
+      class << self
+
+        alias_method :new_orig, :new
+
+        def new(*args)
+          ExceptionConvertingDelegator.new(new_orig(*args), "NativeException", RuntimeError)
+        end
+
+      end
+
       # @return [Akephalos::Page] the current page
       attr_reader :page
 

--- a/lib/akephalos/exception_handling_delegators.rb
+++ b/lib/akephalos/exception_handling_delegators.rb
@@ -1,0 +1,66 @@
+require 'delegate'
+
+##
+# This class can be used to wrap an object so that any exceptions raised by the object's methods are recued and passed to a specified exception_handler block
+#
+class ExceptionCatchingDelegator < SimpleDelegator
+
+  ##
+  # * *Args* :
+  #   - ++ -> delgate - object to be wrapped
+  #   - ++ -> exception_handler - block to handle rescued exeptions (will be called with yield(exception))
+  #
+  def initialize(delegate, exception_handler)
+    super(delegate)
+    @exception_handler = exception_handler
+  end
+
+  ##
+  # Override of method_missing to rescue exceptions and pass them to the exception_handler
+  #
+  def method_missing(m, *args, &block)
+    begin
+      return super(m, *args, &block)
+    rescue Exception => exception
+      @exception_handler.yield(exception)
+    end
+  end
+
+end
+
+##
+# This class can be used to wrap an object so that exceptions matching a given type are rescued and then raised as another type.
+#
+# This kind of exception converting is most of use when dealing with exceptions passed across DRb where a remote
+# exception class may not exist on the client-side.
+#
+class ExceptionConvertingDelegator < ExceptionCatchingDelegator
+  
+  ##
+  # * *Args* :
+  #   - ++ -> delgate - object to be wrapped
+  #   - ++ -> exception_type_to_catch - an exception class or name of an exception class that will be used to match (in a regular-expression sense) the name of exceptions thrown by the delegate's methods
+  #   - ++ -> exception_type_to_throw - the exception class that will be used to create and raise a new exception
+  #
+  def initialize(delegate, exception_type_to_catch = Exception, exception_type_to_throw = RuntimeError)
+
+    handler = lambda do |e|
+      
+      raise e unless e.class.name =~ Regexp.new(exception_type_to_catch.to_s)
+      
+      # Create and raise a RuntimeError
+      message = e.class.name
+      unless e.message.nil? || e.message.size == 0
+        message << " "
+        message << e.message
+      end
+      new_exception = exception_type_to_throw.new(message)
+      new_exception.set_backtrace(e.backtrace)
+      raise new_exception
+    end
+
+    super(delegate, handler)
+
+  end
+
+end

--- a/lib/akephalos/node.rb
+++ b/lib/akephalos/node.rb
@@ -3,6 +3,17 @@ module Akephalos
   # Akephalos::Node wraps HtmlUnit's DOMNode class, providing a simple API for
   # interacting with an element on the page.
   class Node
+    
+    class << self
+    
+      alias_method :new_orig, :new
+    
+      def new(*args)
+        ExceptionConvertingDelegator.new(new_orig(*args), "NativeException", RuntimeError)
+      end
+    
+    end
+
     # @param [HtmlUnit::DOMNode] node
     def initialize(node)
       @nodes = []

--- a/lib/akephalos/page.rb
+++ b/lib/akephalos/page.rb
@@ -3,6 +3,17 @@ module Akephalos
   # Akephalos::Page wraps HtmlUnit's HtmlPage class, exposing an API for
   # interacting with a page in the browser.
   class Page
+    
+    class << self
+    
+      alias_method :new_orig, :new
+    
+      def new(*args)
+        ExceptionConvertingDelegator.new(new_orig(*args), "NativeException", RuntimeError)
+      end
+    
+    end
+    
     # @param [HtmlUnit::HtmlPage] page
     def initialize(page)
       @nodes = []

--- a/lib/akephalos/remote_client.rb
+++ b/lib/akephalos/remote_client.rb
@@ -1,10 +1,6 @@
 require 'socket'
 require 'drb/drb'
 
-# We need to define our own NativeException class for the cases when a native
-# exception is raised by the JRuby DRb server.
-class NativeException < StandardError; end
-
 module Akephalos
 
   # The +RemoteClient+ class provides an interface to an +Akephalos::Client+


### PR DESCRIPTION
Hi Nerian,

The other day I was having a problem with a failing capybara test using akepalos.  The somewhat cryptic output was:

<pre>
   And I press "Finalise Selected"                                                   # features/step_definitions/web_steps.rb:27
     java.lang.NullPointerException: null (NativeException)
     ./features/step_definitions/web_steps.rb:29:in `block (2 levels) in <top (required)>'
     ./features/step_definitions/web_steps.rb:14:in `with_scope'
     ./features/step_definitions/web_steps.rb:28:in `/^(?:|I )press "([^"]*)"(?: within "([^"]*)")?$/'
     features/wba/results/09_amc_approves_results.feature:28:in `And I press "Finalise Selected"'
</pre>

Unfortunately, I had no chance of trying to work out what the cause of the failure was because the Java stack trace was lost.

After some digging around (including downloading, modifying, and compiling the HtmlUnit source), I found out what my problem was.  However, if this sort of issue occurs sometime again in the future I don't want to have to repeat the process to find out what's wrong.  Having finally seen the Java stack trace I realised my journey would have been shortened significantly if I'd had access to it in the Ruby backtrace.

This pull request is for some modifications which allow us to see the full Java stack trace as a Ruby backtrace.  

The main issue I had to solve is that when akephalos received a NativeException on the server side and then passed it through to the client side, we lost the ability to access the NativeException's data (including the backtrace), due to the missing NativeException class on the plain (non-JRuby) client - this is of course why NativeException needs to be defined in remote_client.rb.  

The solution I took was to convert NativeExceptions to an exception class guaranteed to be on both sides of the link, namely RuntimeError.  I did this by wrapping Node and Page instances using a SimpleDecorator extension.  (Now I think of it, I don't think I actually needed to wrap Pages but since they're one of the 'remote' classes I thought it worthwhile.  Maybe this one should be undone or maybe the other remote classes should be similarly wrapped?)

Now the stack trace information comes through as follows:

<pre>
   And I press "Finalise Selected"                                                   # features/step_definitions/web_steps.rb:27
     NativeException java.lang.NullPointerException: null (RuntimeError)
     (druby://127.0.0.1:63662) com/gargoylesoftware/htmlunit/html/HtmlForm.java:112:in `submit'
     (druby://127.0.0.1:63662) com/gargoylesoftware/htmlunit/html/HtmlSubmitInput.java:75:in `doClickAction'
     (druby://127.0.0.1:63662) com/gargoylesoftware/htmlunit/html/HtmlElement.java:1244:in `click'
     (druby://127.0.0.1:63662) com/gargoylesoftware/htmlunit/html/HtmlElement.java:1195:in `click'
     (druby://127.0.0.1:63662) com/gargoylesoftware/htmlunit/html/HtmlElement.java:1158:in `click'
     ./features/step_definitions/web_steps.rb:29:in `block (2 levels) in <top (required)>'
     ./features/step_definitions/web_steps.rb:14:in `with_scope'
     ./features/step_definitions/web_steps.rb:28:in `/^(?:|I )press "([^"]*)"(?: within "([^"]*)")?$/'
     features/wba/results/09_amc_approves_results.feature:29:in `And I press "Finalise Selected"'
</pre>


Regards,

Brendan
