### PR TITLE
patch for the mac issue with java encoding after the 10.6 Update 11

### DIFF
--- a/bin/akephalos
+++ b/bin/akephalos
@@ -83,6 +83,7 @@ else
 
     java_args = [
      "-Xmx#{options[:akephalos_jvm_max_memory]}M",
+     "-Dfile.encoding=UTF8",
       "-cp", [JRubyJars.core_jar_path, JRubyJars.stdlib_jar_path].join(File::PATH_SEPARATOR),
       "org.jruby.Main",
       "-X+O"


### PR DESCRIPTION
After the update of Mac Os ( http://support.apple.com/kb/DL1573 ), I had issue with utf8 malformed ..., and I found that : http://en.wikipedia.org/wiki/Mac_OS_Roman#Application_notes

So here is the patch :)
