### PR TITLE
Modify Capybara::Driver::Akephalos::url to return absolute URL whether C...

### DIFF
--- a/lib/akephalos/capybara.rb
+++ b/lib/akephalos/capybara.rb
@@ -338,7 +338,11 @@ class Capybara::Driver::Akephalos < Capybara::Driver::Base
   # @param [String] path
   # @return [String] the absolute URL for the given path
   def url(path)
-    rack_server.url(path)
+    if Capybara.run_server
+      rack_server.url(path)
+    else
+      Capybara.app_host + path
+    end
   end
 
 end


### PR DESCRIPTION
Currently Akephalos fails if trying to run Capybara against a remote host.  For example, when given the following config:

```
Capybara.configure do |config|
  config.run_server = false
  config.app_host   = 'http://127.0.0.1:8080'
end
```

... Akephalos will die because it is still trying to fetch absolute URLs from rack_server which isn't running.

This patch modifies Capybara::Driver::Akephalos::url to return the absolute URL whether Capybara is running a server or not.  Necessary when running capyabara/akephalos on remote server.
